### PR TITLE
Moves the default prompt input to --ask argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ Setup your OpenAI API key:
 mochi --save-openai-key "<your openai api key>"
 ```
 
+**Note: Not implemented yet**
+
 ## Usage
 
 Here is a simple example of how to use Mochi:
 
 ```bash
-mochi "What changed since last week?"
+mochi --ask "What changed since last week?"
 ```
+
+**Note: Soon, just running `mochi` will start the interactive chat interface.**
 
 ## Contributing
 

--- a/mochi_code/ask.py
+++ b/mochi_code/ask.py
@@ -17,11 +17,11 @@ class EmptyPromptError(Exception):
 
 def cli():
     parser = argparse.ArgumentParser()
-    parser.add_argument("prompt", type=str, help="Your non-empty prompt to run.")
+    parser.add_argument("--ask", type=str, help="Your non-empty prompt to run.")
     args = parser.parse_args()
 
-    prompt = args.prompt
-    if not prompt.strip():
+    prompt = args.ask
+    if prompt is None or not prompt.strip():
         parser.print_help()
         raise EmptyPromptError("Prompt cannot be empty.")
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -12,11 +12,15 @@ class TestAskCli(TestCase):
         """Test that an empty prompt fails."""
         mock_ask.return_value = None
 
-        MonkeyPatch().setattr("sys.argv", ["mochi", ""])
+        MonkeyPatch().setattr("sys.argv", ["mochi"])
         with raises(EmptyPromptError):
             cli()
 
-        MonkeyPatch().setattr("sys.argv", ["mochi", "         "])
+        MonkeyPatch().setattr("sys.argv", ["mochi", "--ask", ""])
+        with raises(EmptyPromptError):
+            cli()
+
+        MonkeyPatch().setattr("sys.argv", ["mochi", "--ask", "         "])
         with raises(EmptyPromptError):
             cli()
 
@@ -26,7 +30,7 @@ class TestAskCli(TestCase):
         mock_ask.return_value = None
 
         prompt = "test"
-        MonkeyPatch().setattr("sys.argv", ["mochi", prompt])
+        MonkeyPatch().setattr("sys.argv", ["mochi", "--ask", prompt])
         cli()
 
         mock_ask.assert_called_once_with(prompt)


### PR DESCRIPTION
This PR moves the default prompt `mochi "some prompt text"` to the new `--ask` argument `mochi --ask "some prompt text"` in preparation to have `mochi` default to a chat more, as described in #3 

## Changes
* Replaces the argument
* Updates the tests
* Updates readme instructions