### PR TITLE
Simplifies the command routing code

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Analysing the code with pylint
         run: |
           poetry run pylint mochi_code/
-          poetry run mypy mochi_code/
-          poetry run mypy tests/
+          poetry run mypy --check-untyped-defs mochi_code/
+          poetry run mypy --check-untyped-defs tests/
 
       - name: Testing code with pytest
         run: |

--- a/mochi_code/commands/__init__.py
+++ b/mochi_code/commands/__init__.py
@@ -1,4 +1,5 @@
 """Ask command module setup."""
 from mochi_code.commands.ask import setup_ask_command
+from mochi_code.commands.ask import run_ask_command
 
-__all__ = ["setup_ask_command"]
+__all__ = ["setup_ask_command", "run_ask_command"]

--- a/mochi_code/commands/__init__.py
+++ b/mochi_code/commands/__init__.py
@@ -1,5 +1,5 @@
 """Ask command module setup."""
-from mochi_code.commands.ask import setup_ask_command
+from mochi_code.commands.ask import setup_ask_arguments
 from mochi_code.commands.ask import run_ask_command
 
-__all__ = ["setup_ask_command", "run_ask_command"]
+__all__ = ["setup_ask_arguments", "run_ask_command"]

--- a/mochi_code/commands/ask.py
+++ b/mochi_code/commands/ask.py
@@ -2,7 +2,6 @@
 
 import argparse
 from typing import Any
-from typing import Callable
 from dotenv import dotenv_values
 from langchain import LLMChain, PromptTemplate, OpenAI
 
@@ -11,14 +10,13 @@ keys = dotenv_values(".keys")
 
 
 def setup_ask_command(
+    command_name: str,
     subparsers: Any,
-) -> tuple[str, argparse.ArgumentParser, Callable]:
+) -> argparse.ArgumentParser:
     """Setup the ask command."""
-    command_name = "ask"
     ask_parser = subparsers.add_parser(command_name, help="Ask a question to mochi.")
     ask_parser.add_argument("prompt", type=str, help="Your non-empty prompt to run.")
-
-    return command_name, ask_parser, run_ask_command
+    return ask_parser
 
 
 def run_ask_command(args: argparse.Namespace):

--- a/mochi_code/commands/ask.py
+++ b/mochi_code/commands/ask.py
@@ -1,7 +1,6 @@
 """The ask command. This command is used to ask mochi a single question."""
 
 import argparse
-from typing import Any
 from dotenv import dotenv_values
 from langchain import LLMChain, PromptTemplate, OpenAI
 
@@ -9,21 +8,19 @@ from langchain import LLMChain, PromptTemplate, OpenAI
 keys = dotenv_values(".keys")
 
 
-def setup_ask_command(
-    command_name: str,
-    subparsers: Any,
-) -> argparse.ArgumentParser:
-    """Setup the ask command."""
-    ask_parser = subparsers.add_parser(command_name, help="Ask a question to mochi.")
-    ask_parser.add_argument("prompt", type=str, help="Your non-empty prompt to run.")
-    return ask_parser
+def setup_ask_arguments(
+    parser: argparse.ArgumentParser,
+):
+    """Setup the parser with the ask command arguments."""
+    parser.add_argument("prompt", type=str, help="Your non-empty prompt to run.")
 
 
 def run_ask_command(args: argparse.Namespace):
-    """Run the ask command."""
+    """Run the ask command with the provided arguments."""
     prompt = args.prompt
     if prompt is None or not prompt.strip():
         raise ValueError("prompt cannot be empty.")
+
     ask(prompt)
 
 

--- a/mochi_code/mochi.py
+++ b/mochi_code/mochi.py
@@ -6,7 +6,7 @@ It serves as a router to the different subcommands.
 import argparse
 from typing import Callable
 
-from mochi_code.commands import setup_ask_command
+from mochi_code.commands import setup_ask_arguments
 from mochi_code.commands import run_ask_command
 
 
@@ -17,10 +17,14 @@ def cli():
     """Setup the cli environment and run the selected subcommand."""
     root_parser = argparse.ArgumentParser(prog="mochi")
     subparsers = root_parser.add_subparsers(title="subcommands", dest="subcommand")
-    ask_parser: argparse.ArgumentParser = setup_ask_command("ask", subparsers)
+
+    ask_name = "ask"
+    ask_parser = subparsers.add_parser(ask_name, help="Ask a question to mochi.")
+    setup_ask_arguments(ask_parser)
+
     args = root_parser.parse_args()
 
-    if args.subcommand == "ask":
+    if args.subcommand == ask_name:
         _run_command(run_ask_command, args, ask_parser)
     else:
         root_parser.print_help()

--- a/mochi_code/mochi.py
+++ b/mochi_code/mochi.py
@@ -34,16 +34,18 @@ def cli():
     root_parser = argparse.ArgumentParser(prog="mochi")
     subparsers = root_parser.add_subparsers(title="subcommands", dest="subcommand")
 
-    command_parsers = [
-        parser for setup in commands if (parser := setup(subparsers)) is not None
-    ]
+    command_parsers = {
+        # command_name: (command_parser, command)
+        [parser[0]]: (parser[1], parser[2])
+        for setup in commands
+        if (parser := setup(subparsers)) is not None
+    }
 
     args = root_parser.parse_args()
 
-    for command_name, command_parser, command in command_parsers:
-        if args.subcommand == command_name:
-            _run_command(command, args, command_parser)
-            break
+    if args.subcommand in command_parsers:
+        command_parser, command = command_parsers[args.subcommand]
+        _run_command(command, args, command_parser)
     else:
         root_parser.print_help()
 

--- a/mochi_code/mochi.py
+++ b/mochi_code/mochi.py
@@ -1,57 +1,35 @@
 """This file sets up the mochi subcommands, validates cli user input and calls
 out to the subcommands.
-
-Subcommands are setup by adding a setup function to the commands list, which
-will add the sub parsers but also return the command function to run when the
-user calls the subcommand.
-
-The setup function tells the cli what subcommand name to match, what parser to
-use and what function to call when the subcommand is called.
+It serves as a router to the different subcommands.
 """
 
 import argparse
 from typing import Callable
-from typing import Any
 
 from mochi_code.commands import setup_ask_command
+from mochi_code.commands import run_ask_command
 
 
-CommandSetupType = Callable[
-    [
-        Any,
-    ],
-    tuple[str, argparse.ArgumentParser, Callable[[argparse.Namespace], None]],
-]
-
-# commands includes a list of setup functions for each command.
-# The setup function is responsible for adding the expected arguments for the
-# command.
-commands: list[CommandSetupType] = [setup_ask_command]
+CommandType = Callable[[argparse.Namespace], None]
 
 
 def cli():
     """Setup the cli environment and run the selected subcommand."""
     root_parser = argparse.ArgumentParser(prog="mochi")
     subparsers = root_parser.add_subparsers(title="subcommands", dest="subcommand")
-
-    command_parsers = {
-        # command_name: (command_parser, command)
-        [parser[0]]: (parser[1], parser[2])
-        for setup in commands
-        if (parser := setup(subparsers)) is not None
-    }
-
+    ask_parser: argparse.ArgumentParser = setup_ask_command("ask", subparsers)
     args = root_parser.parse_args()
 
-    if args.subcommand in command_parsers:
-        command_parser, command = command_parsers[args.subcommand]
-        _run_command(command, args, command_parser)
+    if args.subcommand == "ask":
+        _run_command(run_ask_command, args, ask_parser)
     else:
         root_parser.print_help()
 
 
 def _run_command(
-    command, args: argparse.Namespace, command_parser: argparse.ArgumentParser
+    command: CommandType,
+    args: argparse.Namespace,
+    command_parser: argparse.ArgumentParser,
 ):
     """Run the command and exit if an error occurred."""
     try:


### PR DESCRIPTION
# This PR
Simplifies the cli commands routing code and moves it closer to the cli function.
The code is currently second guessing the future and made it overly complex (late night coding...).

Even though it's good to have each command file be self-contained (args setup and running), we only have one command at the moment and another 1 planned (excluding the default, no subcommand call).

## Changes
* Simplifies the command registry in mochi (no more list of commands that return complex types)
* Moves creating the parser to `mochi.py`
* Hardcodes the conditions to run the command
* Adds tests for the routing
* Improves the checks in the build