### PR TITLE
Use the project details to improve the prompts

### DIFF
--- a/.mochi/project_details.json
+++ b/.mochi/project_details.json
@@ -1,0 +1,1 @@
+{"language": "python", "config_file": "pyproject.toml", "package_manager": "poetry", "dependencies": ["python", "langchain", "python-dotenv", "openai", "pydantic", "retry2", "pytest", "pylint", "mypy", "yapf", "types-retry"]}

--- a/.mochi/project_details.json
+++ b/.mochi/project_details.json
@@ -1,1 +1,0 @@
-{"language": "python", "dependencies": "pyproject.toml", "package_manager": "poetry"}

--- a/.mochi/project_details.json
+++ b/.mochi/project_details.json
@@ -1,0 +1,1 @@
+{"language": "python", "dependencies": "pyproject.toml", "package_manager": "poetry"}

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,5 @@
 [MASTER]
+extension-pkg-whitelist=pydantic
 
 [FORMAT]
 max-line-length=80

--- a/mochi_code/code/__init__.py
+++ b/mochi_code/code/__init__.py
@@ -1,0 +1,4 @@
+"""__init__.py"""
+from .project_details import ProjectDetails
+
+__all__ = ["ProjectDetails"]

--- a/mochi_code/code/__init__.py
+++ b/mochi_code/code/__init__.py
@@ -1,4 +1,4 @@
 """__init__.py"""
-from .project_details import ProjectDetails
+from .project_details import ProjectDetails, ProjectDetailsWithDependencies
 
-__all__ = ["ProjectDetails"]
+__all__ = ["ProjectDetails", "ProjectDetailsWithDependencies"]

--- a/mochi_code/code/mochi_config.py
+++ b/mochi_code/code/mochi_config.py
@@ -3,6 +3,8 @@
 import pathlib
 from typing import Optional
 
+from mochi_code.code import ProjectDetails
+
 MOCHI_DIR_NAME = ".mochi"
 
 
@@ -39,12 +41,15 @@ def search_mochi_config(
     return mochi_path if mochi_path.exists() else None
 
 
-def create_config(project_path: pathlib.Path) -> pathlib.PurePath:
+def create_config(project_path: pathlib.Path,
+                  project_details: ProjectDetails) -> pathlib.PurePath:
     """Create the mochi config file for the project.
 
     Args:
         project_path (pathlib.Path): The path to the project to initialize (the
         config folder will be created here).
+        project_details (ProjectDetails): The details of the project to save in
+        the config.
 
     Returns:
         pathlib.PurePath: The path to the mochi config dir.
@@ -53,6 +58,11 @@ def create_config(project_path: pathlib.Path) -> pathlib.PurePath:
         raise ValueError("Cannot create a mochi config in a file.")
 
     mochi_root = project_path / MOCHI_DIR_NAME
-    mochi_root.mkdir()
+    mochi_root.mkdir(parents=True)
+
+    project_details_path = mochi_root / "project_details.json"
+    with open(project_details_path, "w",
+              encoding="utf-8") as project_details_file:
+        project_details_file.write(project_details.json())
 
     return mochi_root

--- a/mochi_code/code/mochi_config.py
+++ b/mochi_code/code/mochi_config.py
@@ -4,7 +4,7 @@ import pathlib
 import json
 from typing import Optional
 
-from mochi_code.code import ProjectDetails
+from mochi_code.code import ProjectDetailsWithDependencies
 
 MOCHI_DIR_NAME = ".mochi"
 
@@ -42,15 +42,16 @@ def search_mochi_config(
     return mochi_path if mochi_path.exists() else None
 
 
-def create_config(project_path: pathlib.Path,
-                  project_details: ProjectDetails) -> pathlib.PurePath:
+def create_config(
+        project_path: pathlib.Path,
+        project_details: ProjectDetailsWithDependencies) -> pathlib.PurePath:
     """Create the mochi config file for the project.
 
     Args:
         project_path (pathlib.Path): The path to the project to initialize (the
         config folder will be created here).
-        project_details (ProjectDetails): The details of the project to save in
-        the config.
+        project_details (ProjectDetailsWithDependencies): The details of the 
+        project to save in the config.
 
     Returns:
         pathlib.PurePath: The path to the mochi config dir.
@@ -67,22 +68,24 @@ def create_config(project_path: pathlib.Path,
     return mochi_root
 
 
-def save_project_details(project_details_path: pathlib.Path,
-                         project_details: ProjectDetails) -> None:
+def save_project_details(
+        project_details_path: pathlib.Path,
+        project_details: ProjectDetailsWithDependencies) -> None:
     """Save the project details to the mochi config file. This will overwrite!
 
     Args:
         project_details_path (pathlib.Path): The path to the project details 
         json file.
-        project_details (ProjectDetails): The details of the project to save in
-        the config.
+        project_details (ProjectDetailsWithDependencies): The details of the 
+        project to save in the config.
     """
     with open(project_details_path, "w",
               encoding="utf-8") as project_details_file:
         project_details_file.write(project_details.json())
 
 
-def load_project_details(project_details_path: pathlib.Path) -> ProjectDetails:
+def load_project_details(
+        project_details_path: pathlib.Path) -> ProjectDetailsWithDependencies:
     """Load the project details from the mochi config file.
 
     Args:
@@ -90,8 +93,9 @@ def load_project_details(project_details_path: pathlib.Path) -> ProjectDetails:
         file.
 
     Returns:
-        ProjectDetails: The project details loaded from the config.
+        ProjectDetailsWithDependencies: The project details loaded from the 
+        config.
     """
     with open(project_details_path, "r",
               encoding="utf-8") as project_details_file:
-        return ProjectDetails(**json.load(project_details_file))
+        return ProjectDetailsWithDependencies(**json.load(project_details_file))

--- a/mochi_code/code/mochi_config.py
+++ b/mochi_code/code/mochi_config.py
@@ -39,15 +39,20 @@ def search_mochi_config(
     return mochi_path if mochi_path.exists() else None
 
 
-def create_config(project_path: pathlib.Path) -> None:
+def create_config(project_path: pathlib.Path) -> pathlib.PurePath:
     """Create the mochi config file for the project.
 
     Args:
         project_path (pathlib.Path): The path to the project to initialize (the
         config folder will be created here).
+
+    Returns:
+        pathlib.PurePath: The path to the mochi config dir.
     """
     if project_path.is_file():
         raise ValueError("Cannot create a mochi config in a file.")
 
     mochi_root = project_path / MOCHI_DIR_NAME
     mochi_root.mkdir()
+
+    return mochi_root

--- a/mochi_code/code/mochi_config.py
+++ b/mochi_code/code/mochi_config.py
@@ -1,6 +1,7 @@
 """Module for handling mochi config files."""
 
 import pathlib
+import json
 from typing import Optional
 
 from mochi_code.code import ProjectDetails
@@ -61,8 +62,36 @@ def create_config(project_path: pathlib.Path,
     mochi_root.mkdir(parents=True)
 
     project_details_path = mochi_root / "project_details.json"
+    save_project_details(project_details_path, project_details)
+
+    return mochi_root
+
+
+def save_project_details(project_details_path: pathlib.Path,
+                         project_details: ProjectDetails) -> None:
+    """Save the project details to the mochi config file. This will overwrite!
+
+    Args:
+        project_details_path (pathlib.Path): The path to the project details 
+        json file.
+        project_details (ProjectDetails): The details of the project to save in
+        the config.
+    """
     with open(project_details_path, "w",
               encoding="utf-8") as project_details_file:
         project_details_file.write(project_details.json())
 
-    return mochi_root
+
+def load_project_details(project_details_path: pathlib.Path) -> ProjectDetails:
+    """Load the project details from the mochi config file.
+
+    Args:
+        project_details_path (pathlib.Path): The path to the project details 
+        file.
+
+    Returns:
+        ProjectDetails: The project details loaded from the config.
+    """
+    with open(project_details_path, "r",
+              encoding="utf-8") as project_details_file:
+        return ProjectDetails(**json.load(project_details_file))

--- a/mochi_code/code/project_details.py
+++ b/mochi_code/code/project_details.py
@@ -1,0 +1,17 @@
+"""The class used to define the project details. This is used to generate the
+mochi config."""
+
+from pydantic import BaseModel, Field
+
+
+class ProjectDetails(BaseModel):
+    """The details of a project."""
+    language: str = Field(
+        description=
+        "name of the programming language of a project with these files")
+    dependencies: str = Field(
+        description=
+        "single config file defining the list of dependencies of the " +
+        "project, excluding lock file!")
+    package_manager: str = Field(
+        description="package manager name or 'unknown'")

--- a/mochi_code/code/project_details.py
+++ b/mochi_code/code/project_details.py
@@ -9,9 +9,14 @@ class ProjectDetails(BaseModel):
     language: str = Field(
         description=
         "name of the programming language of a project with these files")
-    dependencies: str = Field(
+    config_file: str = Field(
         description=
         "single config file defining the list of dependencies of the " +
         "project, excluding lock file!")
     package_manager: str = Field(
         description="package manager name or 'unknown'")
+
+
+class ProjectDetailsWithDependencies(ProjectDetails):
+    """The complete details of a project."""
+    dependencies: list[str] = Field("list of dependencies of the project")

--- a/mochi_code/commands/ask.py
+++ b/mochi_code/commands/ask.py
@@ -37,6 +37,7 @@ def ask(prompt: str) -> None:
                  callbacks=[StreamingStdOutCallbackHandler()],
                  temperature=0.9,
                  openai_api_key=keys["OPENAI_API_KEY"])  # type: ignore
+
     template = PromptTemplate(
         input_variables=["user_prompt"],
         template="""You are an great software engineer helping other engineers.
@@ -50,4 +51,5 @@ def ask(prompt: str) -> None:
         Please answer this query: '{user_prompt}'""",
     )
     chain = LLMChain(llm=llm, prompt=template)
+
     chain.run(prompt)

--- a/mochi_code/commands/init.py
+++ b/mochi_code/commands/init.py
@@ -61,7 +61,8 @@ def init(project_path: pathlib.Path) -> None:
     project_details = _get_project_details(project_files)
 
     print("🤖 Gathering list of dependencies...")
-    dependencies = _get_dependencies_list(project_path)
+    dependencies = _get_dependencies_list(
+        pathlib.Path(project_details.config_file))
     complete_project_details = ProjectDetailsWithDependencies(
         **project_details.dict(), dependencies=dependencies)
 

--- a/mochi_code/commands/init.py
+++ b/mochi_code/commands/init.py
@@ -66,7 +66,7 @@ def init(project_path: pathlib.Path) -> None:
 
     config_path = create_config(project_path, complete_project_details)
 
-    config_display_uri = config_path.relative_to(project_path).as_uri()
+    config_display_uri = config_path.relative_to(project_path).as_posix()
     print(f"🤖 Created the config at {config_display_uri}")
 
 
@@ -111,4 +111,7 @@ def _get_dependencies_list(dependencies_config_path: pathlib.Path) -> list[str]:
     Returns:
         list[str]: The list of dependencies or empty if none could be found.
     """
+    if not dependencies_config_path.exists():
+        return []
+
     return []

--- a/mochi_code/commands/init.py
+++ b/mochi_code/commands/init.py
@@ -7,27 +7,14 @@ import pathlib
 from dotenv import dotenv_values
 from langchain import LLMChain, OpenAI, PromptTemplate
 from langchain.output_parsers import PydanticOutputParser
-from pydantic import BaseModel, Field
 from retry import retry
 
+from mochi_code.code import ProjectDetails
 from mochi_code.code.mochi_config import create_config, search_mochi_config
 from mochi_code.commands.exceptions import MochiCannotContinue
 
 # Load keys for the different model backends. This needs to be setup separately.
 keys = dotenv_values(".keys")
-
-
-class ProjectDetails(BaseModel):
-    """The details of a project."""
-    language: str = Field(
-        description=
-        "name of the programming language of a project with these files")
-    dependencies: str = Field(
-        description=
-        "single config file defining the list of dependencies of the " +
-        "project, excluding lock file!")
-    package_manager: str = Field(
-        description="package manager name or 'unknown'")
 
 
 def setup_init_arguments(parser: argparse.ArgumentParser) -> None:

--- a/mochi_code/commands/init.py
+++ b/mochi_code/commands/init.py
@@ -4,8 +4,30 @@ project."""
 import argparse
 import pathlib
 
+from dotenv import dotenv_values
+from langchain import LLMChain, OpenAI, PromptTemplate
+from langchain.output_parsers import PydanticOutputParser
+from pydantic import BaseModel, Field
+from retrying import retry
+
 from mochi_code.code.mochi_config import create_config, search_mochi_config
 from mochi_code.commands.exceptions import MochiCannotContinue
+
+# Load keys for the different model backends. This needs to be setup separately.
+keys = dotenv_values(".keys")
+
+
+class ProjectDetails(BaseModel):
+    """The details of a project."""
+    language: str = Field(
+        description=
+        "name of the programming language of a project with these files")
+    dependencies: str = Field(
+        description=
+        "single config file defining the list of dependencies of the " +
+        "project, excluding lock file!")
+    package_manager: str = Field(
+        description="package manager name or 'unknown'")
 
 
 def setup_init_arguments(parser: argparse.ArgumentParser) -> None:
@@ -14,7 +36,8 @@ def setup_init_arguments(parser: argparse.ArgumentParser) -> None:
     Args:
         parser (argparse.ArgumentParser): The parser to add the arguments to.
     """
-    parser.add_argument("-f", "--force",
+    parser.add_argument("-f",
+                        "--force",
                         action="store_true",
                         help="Force creating the config, without overriding.")
 
@@ -44,4 +67,46 @@ def init(project_path: pathlib.Path) -> None:
         config folder will be created here).
     """
     print(f"⚙️ Initializing mochi for project '{project_path}'.")
-    create_config(project_path)
+    config_path = create_config(project_path)
+
+    print("🤖 Gathering information about your project...")
+
+    project_files = [p.name for p in project_path.glob("*")]
+    project_details = _get_project_details(project_files)
+
+    # write a json file named 'project_details.json' in the config folder with
+    # the project_details.json() content
+    project_details_path = config_path / "project_details.json"
+    with open(project_details_path, "w",
+              encoding="utf-8") as project_details_file:
+        project_details_file.write(project_details.json())
+
+
+@retry(stop_max_attempt_number=3)
+def _get_project_details(project_files: list[str]) -> ProjectDetails:
+    """Get the details of a project from the user.
+
+    Returns:
+        ProjectDetails: The details of the project.
+    """
+    llm = OpenAI(temperature=0.9,
+                 openai_api_key=keys["OPENAI_API_KEY"])  # type: ignore
+
+    parser = PydanticOutputParser(pydantic_object=ProjectDetails,)
+    template = PromptTemplate(
+        input_variables=["files"],
+        partial_variables={
+            "format_instructions": parser.get_format_instructions()
+        },
+        template="You are a professional software engineer helping other " +
+        "engineers. I'm going to provide a comma separated list of " +
+        "files from a project and you need to reply with some " +
+        "information about the project in a valid single line JSON " +
+        "format with lower case values.\n{format_instructions}\nOutput must " +
+        "be a valid json!\nHere's the list of files:\n{files}",
+    )
+    chain = LLMChain(llm=llm, prompt=template)
+
+    response = chain.run(files=",".join(project_files), verbose=True)
+
+    return parser.parse(response)

--- a/mochi_code/commands/init.py
+++ b/mochi_code/commands/init.py
@@ -8,7 +8,7 @@ from dotenv import dotenv_values
 from langchain import LLMChain, OpenAI, PromptTemplate
 from langchain.output_parsers import PydanticOutputParser
 from pydantic import BaseModel, Field
-from retrying import retry
+from retry import retry
 
 from mochi_code.code.mochi_config import create_config, search_mochi_config
 from mochi_code.commands.exceptions import MochiCannotContinue
@@ -82,7 +82,7 @@ def init(project_path: pathlib.Path) -> None:
         project_details_file.write(project_details.json())
 
 
-@retry(stop_max_attempt_number=3)
+@retry(tries=3)
 def _get_project_details(project_files: list[str]) -> ProjectDetails:
     """Get the details of a project from the user.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1127,6 +1127,31 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "retrying"
+version = "1.3.4"
+description = "Retrying"
+optional = false
+python-versions = "*"
+files = [
+    {file = "retrying-1.3.4-py3-none-any.whl", hash = "sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35"},
+    {file = "retrying-1.3.4.tar.gz", hash = "sha256:345da8c5765bd982b1d1915deb9102fd3d1f7ad16bd84a9700b85f64d24e8f3e"},
+]
+
+[package.dependencies]
+six = ">=1.7.0"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.15"
 description = "Database Abstraction Library"
@@ -1490,4 +1515,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "002f5ee2b9adf1e2aa0be005bb11c8df8f00d4567668b613ebf05385a5f6bdff"
+content-hash = "b915b4a205b441ea32fcf17d0db19ddc3cac70db3b0997977634d3cc9a45f4d4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -296,6 +296,17 @@ typing-inspect = ">=0.4.0"
 dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (>=6.2.3)", "simplejson", "types-dataclasses"]
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
 name = "dill"
 version = "0.3.6"
 description = "serialize all of python"
@@ -1127,29 +1138,17 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "retrying"
-version = "1.3.4"
-description = "Retrying"
+name = "retry2"
+version = "0.9.5"
+description = "Easy to use retry decorator."
 optional = false
-python-versions = "*"
+python-versions = ">=2.6"
 files = [
-    {file = "retrying-1.3.4-py3-none-any.whl", hash = "sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35"},
-    {file = "retrying-1.3.4.tar.gz", hash = "sha256:345da8c5765bd982b1d1915deb9102fd3d1f7ad16bd84a9700b85f64d24e8f3e"},
+    {file = "retry2-0.9.5-py2.py3-none-any.whl", hash = "sha256:f7fee13b1e15d0611c462910a6aa72a8919823988dd0412152bc3719c89a4e55"},
 ]
 
 [package.dependencies]
-six = ">=1.7.0"
-
-[[package]]
-name = "six"
-version = "1.16.0"
-description = "Python 2 and 3 compatibility utilities"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
-]
+decorator = ">=3.4.2"
 
 [[package]]
 name = "sqlalchemy"
@@ -1283,6 +1282,17 @@ dev = ["py-make (>=0.1.0)", "twine", "wheel"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
+
+[[package]]
+name = "types-retry"
+version = "0.9.9.3"
+description = "Typing stubs for retry"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-retry-0.9.9.3.tar.gz", hash = "sha256:1b7a0a04adf12f21237e76833574a9a8f755f88889c226ad99d6e3bfa5b6e3c8"},
+    {file = "types_retry-0.9.9.3-py3-none-any.whl", hash = "sha256:238fdb08794862d951187250e443257bb09e927404c88edf7ce88618f4357c2a"},
+]
 
 [[package]]
 name = "typing-extensions"
@@ -1515,4 +1525,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "b915b4a205b441ea32fcf17d0db19ddc3cac70db3b0997977634d3cc9a45f4d4"
+content-hash = "6fad2f1bacf5f813c124af004028a3601e7491ac031caa96f8e3bf4da539bf41"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1490,4 +1490,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "0fdaf27835622365028937ef6ecee905a9beb3074e214fec087aef9057dd3541"
+content-hash = "002f5ee2b9adf1e2aa0be005bb11c8df8f00d4567668b613ebf05385a5f6bdff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ langchain = "^0.0.181"
 python-dotenv = "^1.0.0"
 openai = "^0.27.7"
 pydantic = "1.10.8"
+retrying = "^1.3.4"
 
 
 [tool.poetry.group.test.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ python = "^3.10"
 langchain = "^0.0.181"
 python-dotenv = "^1.0.0"
 openai = "^0.27.7"
+pydantic = "1.10.8"
 
 
 [tool.poetry.group.test.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ langchain = "^0.0.181"
 python-dotenv = "^1.0.0"
 openai = "^0.27.7"
 pydantic = "1.10.8"
-retrying = "^1.3.4"
+retry2 = "^0.9.5"
 
 
 [tool.poetry.group.test.dependencies]
@@ -23,6 +23,7 @@ pytest = "^7.3.1"
 pylint = "^2.17.4"
 mypy = "^1.3.0"
 yapf = "^0.33.0"
+types-retry = "^0.9.9.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/code/test_mochi_config.py
+++ b/tests/code/test_mochi_config.py
@@ -4,11 +4,8 @@ import pathlib
 import tempfile
 from unittest import TestCase
 
-from mochi_code.code.mochi_config import (
-    create_config,
-    search_mochi_config,
-    MOCHI_DIR_NAME
-)
+from mochi_code.code.mochi_config import (create_config, search_mochi_config,
+                                          MOCHI_DIR_NAME)
 
 
 class TestSearchMochiConfig(TestCase):
@@ -116,7 +113,7 @@ class TestCreateConfig(TestCase):
         config_path = create_config(self._root_path)
 
         self.assertTrue(mochi_path.exists())
-        self.assertEquals(config_path, mochi_path)
+        self.assertEqual(config_path, mochi_path)
 
     def test_raises_if_not_directory(self) -> None:
         """Test that the function raises a ValueError if the path is not a

--- a/tests/code/test_mochi_config.py
+++ b/tests/code/test_mochi_config.py
@@ -113,9 +113,10 @@ class TestCreateConfig(TestCase):
 
         self.assertFalse(mochi_path.exists())
 
-        create_config(self._root_path)
+        config_path = create_config(self._root_path)
 
         self.assertTrue(mochi_path.exists())
+        self.assertEquals(config_path, mochi_path)
 
     def test_raises_if_not_directory(self) -> None:
         """Test that the function raises a ValueError if the path is not a

--- a/tests/code/test_mochi_config.py
+++ b/tests/code/test_mochi_config.py
@@ -4,7 +4,7 @@ import pathlib
 import tempfile
 import json
 from unittest import TestCase
-from mochi_code.code import ProjectDetails
+from mochi_code.code import ProjectDetailsWithDependencies
 
 from mochi_code.code.mochi_config import (create_config, load_project_details,
                                           search_mochi_config, MOCHI_DIR_NAME,
@@ -103,9 +103,11 @@ class TestCreateConfig(TestCase):
         # Create a temporary folder as root
         self._root_dir = tempfile.TemporaryDirectory()
         self._root_path = pathlib.Path(self._root_dir.name)
-        self._project_details = ProjectDetails(language="python",
-                                               config_file="testing.yml",
-                                               package_manager="pip")
+        self._project_details = ProjectDetailsWithDependencies(
+            language="python",
+            config_file="testing.yml",
+            package_manager="pip",
+            dependencies=["numpy", "pandas"])
 
     def tearDown(self) -> None:
         self._root_dir.cleanup()
@@ -170,9 +172,11 @@ class TestSaveAndLoadProjectDetails(TestCase):
         # Create a temporary folder as root
         self._root_dir = tempfile.TemporaryDirectory()
         self._root_path = pathlib.Path(self._root_dir.name)
-        self._project_details = ProjectDetails(language="typescript",
-                                               config_file="testing.json",
-                                               package_manager="npm")
+        self._project_details = ProjectDetailsWithDependencies(
+            language="typescript",
+            config_file="testing.json",
+            package_manager="npm",
+            dependencies=["react", "redux"])
 
     def tearDown(self) -> None:
         self._root_dir.cleanup()
@@ -190,9 +194,11 @@ class TestSaveAndLoadProjectDetails(TestCase):
         self.assertEqual(loaded_project_details, self._project_details)
 
         # Test that it actually updates the values
-        new_project_details = ProjectDetails(language="python",
-                                             config_file="testing.yml",
-                                             package_manager="pip")
+        new_project_details = ProjectDetailsWithDependencies(
+            language="python",
+            config_file="testing.yml",
+            package_manager="pip",
+            dependencies=["numpy", "pandas"])
 
         save_project_details(project_details_path, new_project_details)
         loaded_project_details = load_project_details(project_details_path)

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -31,7 +31,7 @@ class TestRunInitCommand(TestCase):
 
         mock_project_details.return_value = ProjectDetails(
             language="python",
-            dependencies="pyproject.toml",
+            config_file="pyproject.toml",
             package_manager="poetry")
         mock_cwd.return_value = start_path
         mock_init.return_value = None
@@ -60,7 +60,7 @@ class TestRunInitCommand(TestCase):
 
         mock_project_details.return_value = ProjectDetails(
             language="python",
-            dependencies="pyproject.toml",
+            config_file="pyproject.toml",
             package_manager="poetry")
         mock_cwd.return_value = start_path
         mock_init.return_value = None
@@ -86,7 +86,7 @@ class TestRunInitCommand(TestCase):
 
         mock_project_details.return_value = ProjectDetails(
             language="python",
-            dependencies="pyproject.toml",
+            config_file="pyproject.toml",
             package_manager="poetry")
         mock_cwd.return_value = start_path
         mock_init.return_value = None
@@ -107,7 +107,7 @@ class TestRunInitCommand(TestCase):
 
         mock_project_details.return_value = ProjectDetails(
             language="python",
-            dependencies="pyproject.toml",
+            config_file="pyproject.toml",
             package_manager="poetry")
         search_mock.return_value = None
         mock_init.return_value = None

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from mochi_code.code.mochi_config import MOCHI_DIR_NAME
 from mochi_code.commands.exceptions import MochiCannotContinue
-from mochi_code.commands.init import run_init_command, init
+from mochi_code.commands.init import run_init_command, init, ProjectDetails
 
 
 class TestRunInitCommand(TestCase):
@@ -17,13 +17,22 @@ class TestRunInitCommand(TestCase):
     @patch("mochi_code.commands.init.search_mochi_config")
     @patch("mochi_code.commands.init.init")
     @patch("mochi_code.commands.init.pathlib.Path.cwd")
-    def test_it_raises_if_already_initialized(self, mock_cwd: MagicMock,
-                                              mock_init: MagicMock,
-                                              mock_search: MagicMock, ) -> None:
+    @patch("mochi_code.commands.init._get_project_details")
+    def test_it_raises_if_already_initialized(
+        self,
+        mock_project_details: MagicMock,
+        mock_cwd: MagicMock,
+        mock_init: MagicMock,
+        mock_search: MagicMock,
+    ) -> None:
         """Test that the function raises if the project is already initialized.
         """
         start_path = pathlib.Path("/some/path")
 
+        mock_project_details.return_value = ProjectDetails(
+            language="python",
+            dependencies="pyproject.toml",
+            package_manager="poetry")
         mock_cwd.return_value = start_path
         mock_init.return_value = None
         mock_search.return_value = start_path / MOCHI_DIR_NAME
@@ -37,13 +46,22 @@ class TestRunInitCommand(TestCase):
     @patch("mochi_code.commands.init.search_mochi_config")
     @patch("mochi_code.commands.init.init")
     @patch("mochi_code.commands.init.pathlib.Path.cwd")
-    def test_it_forces_config_creation(self, mock_cwd: MagicMock,
-                                       mock_init: MagicMock,
-                                       mock_search: MagicMock, ) -> None:
+    @patch("mochi_code.commands.init._get_project_details")
+    def test_it_forces_config_creation(
+        self,
+        mock_project_details: MagicMock,
+        mock_cwd: MagicMock,
+        mock_init: MagicMock,
+        mock_search: MagicMock,
+    ) -> None:
         """Test that the function does not raise with the force argument.
         """
         start_path = pathlib.Path("/some/path")
 
+        mock_project_details.return_value = ProjectDetails(
+            language="python",
+            dependencies="pyproject.toml",
+            package_manager="poetry")
         mock_cwd.return_value = start_path
         mock_init.return_value = None
         mock_search.return_value = start_path.parent / MOCHI_DIR_NAME
@@ -54,13 +72,22 @@ class TestRunInitCommand(TestCase):
     @patch("mochi_code.commands.init.search_mochi_config")
     @patch("mochi_code.commands.init.init")
     @patch("mochi_code.commands.init.pathlib.Path.cwd")
-    def test_it_does_not_override_existing(self, mock_cwd: MagicMock,
-                                           mock_init: MagicMock,
-                                           mock_search: MagicMock, ) -> None:
+    @patch("mochi_code.commands.init._get_project_details")
+    def test_it_does_not_override_existing(
+        self,
+        mock_project_details: MagicMock,
+        mock_cwd: MagicMock,
+        mock_init: MagicMock,
+        mock_search: MagicMock,
+    ) -> None:
         """Test that the function does not create a new config if one already
         exists on the current path."""
         start_path = pathlib.Path("/some/path")
 
+        mock_project_details.return_value = ProjectDetails(
+            language="python",
+            dependencies="pyproject.toml",
+            package_manager="poetry")
         mock_cwd.return_value = start_path
         mock_init.return_value = None
         mock_search.return_value = start_path / MOCHI_DIR_NAME
@@ -71,11 +98,17 @@ class TestRunInitCommand(TestCase):
     @patch("mochi_code.commands.init.search_mochi_config")
     @patch("mochi_code.commands.init.init")
     @patch("mochi_code.commands.init.pathlib.Path.cwd")
-    def test_it_calls_init(self, mock_cwd: MagicMock, mock_init: MagicMock,
+    @patch("mochi_code.commands.init._get_project_details")
+    def test_it_calls_init(self, mock_project_details: MagicMock,
+                           mock_cwd: MagicMock, mock_init: MagicMock,
                            search_mock: MagicMock) -> None:
         """Test that the function calls init with the project path."""
         start_path = pathlib.Path(tempfile.TemporaryDirectory().name)
 
+        mock_project_details.return_value = ProjectDetails(
+            language="python",
+            dependencies="pyproject.toml",
+            package_manager="poetry")
         search_mock.return_value = None
         mock_init.return_value = None
         mock_cwd.return_value = start_path

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -126,6 +126,8 @@ class TestInit(TestCase):
         init(self._root_path)
 
         self.assertTrue(self._mochi_path.exists())
+        mock_dependencies_list.assert_called_once_with(
+            pathlib.Path(mock_project_details.return_value.config_file))
 
         loaded_project_details = load_project_details(self._mochi_path /
                                                       "project_details.json")
@@ -135,3 +137,20 @@ class TestInit(TestCase):
             dependencies=mock_dependencies_list.return_value,
         )
         self.assertEqual(loaded_project_details, expected_project_details)
+
+    @patch("mochi_code.commands.init._get_dependencies_list")
+    @patch("mochi_code.commands.init._get_project_details")
+    def test_does_not_create_config_if_failed(
+            self, mock_project_details: MagicMock,
+            mock_dependencies_list: MagicMock) -> None:
+        """Test that the function does not create a new config if it fails to
+        gather the project details."""
+        mock_project_details.side_effect = ValueError("Some error")
+
+        self.assertFalse(self._mochi_path.exists())
+
+        with self.assertRaises(ValueError):
+            init(self._root_path)
+
+        self.assertFalse(self._mochi_path.exists())
+        mock_dependencies_list.assert_not_called()


### PR DESCRIPTION
Having to always explain the type of project we're working with isn't great.
This PR uses LLMs to get the type of project during `mochi init` and uses those details when prompting for questions.

Progress for #26 